### PR TITLE
[WebImageView] Sending broadcast when bundle is invalid

### DIFF
--- a/src/com/yelp/android/webimageview/WebImageView.java
+++ b/src/com/yelp/android/webimageview/WebImageView.java
@@ -34,7 +34,7 @@ public class WebImageView extends ImageView {
 
 	public static final String EXTRA_IMAGE_URL = "image_url";
 
-	public static final String ACTION_INVALID_BUNDLE_URL = "com.yelp.android.intent.invalid_bundle_url";
+	public static final String ACTION_INVALID_BUNDLE_URL = "com.yelp.android.webimageview.intent.invalid_bundle_url";
 
 	/*
 	 * Returns a drawable resourceId if the provided string name


### PR DESCRIPTION
When an invalud bundle:// image is attempted, we will broadcast this to the app.
