### PR TITLE
Rename guava packages to Yelp to ease gradle dependency woes

### DIFF
--- a/src/com/yelp/android/webimageview/ImageCache.java
+++ b/src/com/yelp/android/webimageview/ImageCache.java
@@ -32,7 +32,7 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.util.Log;
 
-import com.google.common.collect.MapMaker;
+import com.yelp.common.collect.MapMaker;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/com/yelp/common/base/FinalizableReference.java
+++ b/src/com/yelp/common/base/FinalizableReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Google Inc.
+ * Copyright (C) 2007 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-package com.google.common.collect;
+package com.yelp.common.base;
 
 /**
- * Wraps an exception that occured during a computation in a different thread.
+ * Implemented by references that have code to run after garbage collection of
+ * their referents.
  *
+ * @see FinalizableReferenceQueue
  * @author Bob Lee
  */
-public class AsynchronousComputationException extends ComputationException {
+public interface FinalizableReference {
+
   /**
-   * Creates a new instance with the given cause.
+   * Invoked on a background thread after the referent has been garbage
+   * collected unless security restrictions prevented starting a background
+   * thread, in which case this method is invoked when new references
+   * are created.
    */
-  public AsynchronousComputationException(Throwable cause) {
-    super(cause);
-  }
-  private static final long serialVersionUID = 0;
+  void finalizeReferent();
 }

--- a/src/com/yelp/common/base/FinalizableReferenceQueue.java
+++ b/src/com/yelp/common/base/FinalizableReferenceQueue.java
@@ -16,7 +16,7 @@
  * Excessive logging removed by Yelp in 2011
  */
 
-package com.google.common.base;
+package com.yelp.common.base;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -94,7 +94,7 @@ private static final Logger logger
 	  = Logger.getLogger(FinalizableReferenceQueue.class.getName());
 
 private static final String FINALIZER_CLASS_NAME
-	  = "com.google.common.base.internal.Finalizer";
+	  = "com.yelp.common.base.internal.Finalizer";
 
 /** Reference to Finalizer.startFinalizer(). */
 private static final Method startFinalizer;

--- a/src/com/yelp/common/base/FinalizableSoftReference.java
+++ b/src/com/yelp/common/base/FinalizableSoftReference.java
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-package com.google.common.base;
+package com.yelp.common.base;
 
-import java.lang.ref.WeakReference;
+import java.lang.ref.SoftReference;
 
 /**
- * Weak reference with a {@code finalizeReferent()} method which a background
+ * Soft reference with a {@code finalizeReferent()} method which a background
  * thread invokes after the garbage collector reclaims the referent. This is a
  * simpler alternative to using a {@link java.lang.ref.ReferenceQueue}.
  *
  * @author Bob Lee
  */
-public abstract class FinalizableWeakReference<T> extends WeakReference<T>
+public abstract class FinalizableSoftReference<T> extends SoftReference<T>
     implements FinalizableReference {
 
   /**
-   * Constructs a new finalizable weak reference.
+   * Constructs a new finalizable soft reference.
    *
-   * @param referent to weakly reference
+   * @param referent to softly reference
    * @param queue that should finalize the referent
    */
-  protected FinalizableWeakReference(T referent,
+  protected FinalizableSoftReference(T referent,
       FinalizableReferenceQueue queue) {
     super(referent, queue.queue);
     queue.cleanUp();

--- a/src/com/yelp/common/base/FinalizableWeakReference.java
+++ b/src/com/yelp/common/base/FinalizableWeakReference.java
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-package com.google.common.base;
+package com.yelp.common.base;
 
-import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
 
 /**
- * Soft reference with a {@code finalizeReferent()} method which a background
+ * Weak reference with a {@code finalizeReferent()} method which a background
  * thread invokes after the garbage collector reclaims the referent. This is a
  * simpler alternative to using a {@link java.lang.ref.ReferenceQueue}.
  *
  * @author Bob Lee
  */
-public abstract class FinalizableSoftReference<T> extends SoftReference<T>
+public abstract class FinalizableWeakReference<T> extends WeakReference<T>
     implements FinalizableReference {
 
   /**
-   * Constructs a new finalizable soft reference.
+   * Constructs a new finalizable weak reference.
    *
-   * @param referent to softly reference
+   * @param referent to weakly reference
    * @param queue that should finalize the referent
    */
-  protected FinalizableSoftReference(T referent,
+  protected FinalizableWeakReference(T referent,
       FinalizableReferenceQueue queue) {
     super(referent, queue.queue);
     queue.cleanUp();

--- a/src/com/yelp/common/base/Function.java
+++ b/src/com/yelp/common/base/Function.java
@@ -9,7 +9,7 @@
  * governing permissions and limitations under the License.
  */
 
-package com.google.common.base;
+package com.yelp.common.base;
 
 /**
  * A transformation from one object to another. For example, a {@code

--- a/src/com/yelp/common/base/Objects.java
+++ b/src/com/yelp/common/base/Objects.java
@@ -9,7 +9,7 @@
  * governing permissions and limitations under the License.
  */
 
-package com.google.common.base;
+package com.yelp.common.base;
 
 import java.util.Arrays;
 

--- a/src/com/yelp/common/base/internal/Finalizer.java
+++ b/src/com/yelp/common/base/internal/Finalizer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.common.base.internal;
+package com.yelp.common.base.internal;
 
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 
 /**
  * Thread that finalizes referents. All references should implement
- * {@code com.google.common.base.FinalizableReference}.
+ * {@code com.yelp.common.base.FinalizableReference}.
  *
  * <p>While this class is public, we consider it to be *internal* and not part
  * of our published API. It is public so we can access it reflectively across
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
  * loader. For example, dynamically reloading a web application or unloading
  * an OSGi bundle.
  *
- * <p>{@code com.google.common.base.FinalizableReferenceQueue} loads this class
+ * <p>{@code com.yelp.common.base.FinalizableReferenceQueue} loads this class
  * in its own class loader. That way, this class doesn't prevent the main
  * class loader from getting garbage collected, and this class can detect when
  * the main class loader has been garbage collected and stop itself.
@@ -53,7 +53,7 @@ public class Finalizer extends Thread {
 
   /** Name of FinalizableReference.class. */
   private static final String FINALIZABLE_REFERENCE
-      = "com.google.common.base.FinalizableReference";
+      = "com.yelp.common.base.FinalizableReference";
 
   /**
    * Starts the Finalizer thread. FinalizableReferenceQueue calls this method

--- a/src/com/yelp/common/collect/AbstractMapEntry.java
+++ b/src/com/yelp/common/collect/AbstractMapEntry.java
@@ -9,11 +9,11 @@
  * governing permissions and limitations under the License.
  */
 
-package com.google.common.collect;
+package com.yelp.common.collect;
 
 import java.util.Map.Entry;
 
-import com.google.common.base.Objects;
+import com.yelp.common.base.Objects;
 
 /**
  * Implementation of the {@code equals}, {@code hashCode}, and {@code toString}

--- a/src/com/yelp/common/collect/AsynchronousComputationException.java
+++ b/src/com/yelp/common/collect/AsynchronousComputationException.java
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-package com.google.common.collect;
-
-import java.util.Timer;
+package com.yelp.common.collect;
 
 /**
- * Timer used for entry expiration in MapMaker.
+ * Wraps an exception that occured during a computation in a different thread.
+ *
+ * @author Bob Lee
  */
-class ExpirationTimer {
-  static Timer instance = new Timer(true);
+public class AsynchronousComputationException extends ComputationException {
+  /**
+   * Creates a new instance with the given cause.
+   */
+  public AsynchronousComputationException(Throwable cause) {
+    super(cause);
+  }
+  private static final long serialVersionUID = 0;
 }

--- a/src/com/yelp/common/collect/ComputationException.java
+++ b/src/com/yelp/common/collect/ComputationException.java
@@ -9,7 +9,7 @@
  * governing permissions and limitations under the License.
  */
 
-package com.google.common.collect;
+package com.yelp.common.collect;
 
 /**
  * Wraps an exception that occured during a computation.

--- a/src/com/yelp/common/collect/CustomConcurrentHashMap.java
+++ b/src/com/yelp/common/collect/CustomConcurrentHashMap.java
@@ -9,7 +9,7 @@
  * governing permissions and limitations under the License.
  */
 
-package com.google.common.collect;
+package com.yelp.common.collect;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.google.common.base.Function;
+import com.yelp.common.base.Function;
 
 /**
  * A framework for concurrent hash map implementations. The

--- a/src/com/yelp/common/collect/ExpirationTimer.java
+++ b/src/com/yelp/common/collect/ExpirationTimer.java
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.common.collect;
+package com.yelp.common.collect;
+
+import java.util.Timer;
 
 /**
- * Thrown when a computer function returns null. This subclass exists so
- * that our ReferenceCache adapter can differentiate null output from null
- * keys, but we don't want to make this public otherwise.
- *
- * @author Bob Lee
+ * Timer used for entry expiration in MapMaker.
  */
-class NullOutputException extends NullPointerException {
-  public NullOutputException(String s) {
-    super(s);
-  }
-  private static final long serialVersionUID = 0;
+class ExpirationTimer {
+  static Timer instance = new Timer(true);
 }

--- a/src/com/yelp/common/collect/MapMaker.java
+++ b/src/com/yelp/common/collect/MapMaker.java
@@ -9,7 +9,7 @@
  * governing permissions and limitations under the License.
  */
 
-package com.google.common.collect;
+package com.yelp.common.collect;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -24,12 +24,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.FinalizableReferenceQueue;
-import com.google.common.base.FinalizableSoftReference;
-import com.google.common.base.FinalizableWeakReference;
-import com.google.common.base.Function;
-import com.google.common.collect.CustomConcurrentHashMap.ComputingStrategy;
-import com.google.common.collect.CustomConcurrentHashMap.Internals;
+import com.yelp.common.base.FinalizableReferenceQueue;
+import com.yelp.common.base.FinalizableSoftReference;
+import com.yelp.common.base.FinalizableWeakReference;
+import com.yelp.common.base.Function;
+import com.yelp.common.collect.CustomConcurrentHashMap.ComputingStrategy;
+import com.yelp.common.collect.CustomConcurrentHashMap.Internals;
 
 /**
  * A {@link ConcurrentMap} builder, providing any combination of these features:

--- a/src/com/yelp/common/collect/NullOutputException.java
+++ b/src/com/yelp/common/collect/NullOutputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007 Google Inc.
+ * Copyright (C) 2009 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package com.google.common.base;
+package com.yelp.common.collect;
 
 /**
- * Implemented by references that have code to run after garbage collection of
- * their referents.
+ * Thrown when a computer function returns null. This subclass exists so
+ * that our ReferenceCache adapter can differentiate null output from null
+ * keys, but we don't want to make this public otherwise.
  *
- * @see FinalizableReferenceQueue
  * @author Bob Lee
  */
-public interface FinalizableReference {
-
-  /**
-   * Invoked on a background thread after the referent has been garbage
-   * collected unless security restrictions prevented starting a background
-   * thread, in which case this method is invoked when new references
-   * are created.
-   */
-  void finalizeReferent();
+class NullOutputException extends NullPointerException {
+  public NullOutputException(String s) {
+    super(s);
+  }
+  private static final long serialVersionUID = 0;
 }


### PR DESCRIPTION
The Yelp used some of the Guava classes brought in by WIV, which caused an issue when dealing with dependencies that _actually_ use Guava. This was the simplest fix. 
