### PR TITLE
Fixes a leak caused by the image loader handler retaining the image view

### DIFF
--- a/src/com/yelp/android/webimageview/ImageLoader.java
+++ b/src/com/yelp/android/webimageview/ImageLoader.java
@@ -253,7 +253,7 @@ public class ImageLoader implements Runnable {
 			// fetch the image in the background
 			executor.execute(loader);
 		} else if (handler instanceof WebImageLoaderHandler) {
-			WebImageView view = ((WebImageLoaderHandler)handler).mView.get();
+			WebImageView view = (WebImageView)handler.getImageView();
 			if (view != null) {
 				view.setImageBitmap(image, true);
 				loader.notifyImageLoaded(image);

--- a/src/com/yelp/android/webimageview/ImageLoader.java
+++ b/src/com/yelp/android/webimageview/ImageLoader.java
@@ -253,7 +253,7 @@ public class ImageLoader implements Runnable {
 			// fetch the image in the background
 			executor.execute(loader);
 		} else if (handler instanceof WebImageLoaderHandler) {
-			WebImageView view = (WebImageView)handler.getImageView();
+			WebImageView view = ((WebImageLoaderHandler)handler).getImageView();
 			if (view != null) {
 				view.setImageBitmap(image, true);
 				loader.notifyImageLoaded(image);

--- a/src/com/yelp/android/webimageview/ImageLoaderHandler.java
+++ b/src/com/yelp/android/webimageview/ImageLoaderHandler.java
@@ -20,6 +20,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.widget.ImageView;
+
+import java.lang.ref.WeakReference;
+
 /**
  * An ImageLoaderHandler both handles the receiving of an image and acts as a
  * request for image download. Instances of this class can be passed to the
@@ -32,11 +35,11 @@ import android.widget.ImageView;
  */
 public class ImageLoaderHandler extends Handler {
 
-    private final ImageView imageView;
+    private final WeakReference<ImageView> mWeakImageView;
     protected long priority;
 
     public ImageLoaderHandler(ImageView imageView) {
-        this.imageView = imageView;
+        mWeakImageView = new WeakReference<ImageView>(imageView);
         priority = 0;
     }
 
@@ -45,12 +48,14 @@ public class ImageLoaderHandler extends Handler {
         if (msg.what == ImageLoader.HANDLER_MESSAGE_ID) {
             Bundle data = msg.getData();
             Bitmap bitmap = data.getParcelable(ImageLoader.BITMAP_EXTRA);
-            imageView.setImageBitmap(bitmap);
+            if (mWeakImageView.get() != null) {
+                mWeakImageView.get().setImageBitmap(bitmap);
+            }
         }
     }
 
     ImageView getImageView() {
-        return imageView;
+        return mWeakImageView.get();
     }
 
 }

--- a/src/com/yelp/android/webimageview/ImageLoaderHandler.java
+++ b/src/com/yelp/android/webimageview/ImageLoaderHandler.java
@@ -33,13 +33,13 @@ import java.lang.ref.WeakReference;
  * @author Matthias Käppler, Greg Giacovelli
  *
  */
-public class ImageLoaderHandler extends Handler {
+public class ImageLoaderHandler<T extends ImageView> extends Handler {
 
-    private final WeakReference<ImageView> mWeakImageView;
+    private final WeakReference<T> mWeakImageView;
     protected long priority;
 
-    public ImageLoaderHandler(ImageView imageView) {
-        mWeakImageView = new WeakReference<ImageView>(imageView);
+    public ImageLoaderHandler(T imageView) {
+        mWeakImageView = new WeakReference<T>(imageView);
         priority = 0;
     }
 
@@ -54,7 +54,7 @@ public class ImageLoaderHandler extends Handler {
         }
     }
 
-    ImageView getImageView() {
+    T getImageView() {
         return mWeakImageView.get();
     }
 

--- a/src/com/yelp/android/webimageview/WebImageView.java
+++ b/src/com/yelp/android/webimageview/WebImageView.java
@@ -255,7 +255,7 @@ public class WebImageView extends ImageView {
 	 *
 	 * @author greg/pretz/alexd
 	 */
-	public static class WebImageLoaderHandler extends ImageLoaderHandler {
+	public static class WebImageLoaderHandler extends ImageLoaderHandler<WebImageView> {
 		String mUrl;
 		private final WeakReference<ImageLoadedCallback> mCallback;
 
@@ -269,7 +269,7 @@ public class WebImageView extends ImageView {
 
 		@Override
 		public void handleMessage(Message msg) {
-			WebImageView view = (WebImageView)getImageView();
+			WebImageView view = getImageView();
 			if (view == null) {
 				return;
 			}

--- a/src/com/yelp/android/webimageview/WebImageView.java
+++ b/src/com/yelp/android/webimageview/WebImageView.java
@@ -257,13 +257,11 @@ public class WebImageView extends ImageView {
 	 */
 	public static class WebImageLoaderHandler extends ImageLoaderHandler {
 		String mUrl;
-		public final WeakReference<WebImageView> mView;
 		private final WeakReference<ImageLoadedCallback> mCallback;
 
 		public WebImageLoaderHandler(String url, WebImageView view,
 				long priority, ImageLoadedCallback callback) {
 			super(view);
-			mView = new WeakReference<WebImageView>(view);
 			mUrl = url;
 			mCallback = new WeakReference<WebImageView.ImageLoadedCallback>(callback);
 			super.priority = priority;
@@ -271,7 +269,7 @@ public class WebImageView extends ImageView {
 
 		@Override
 		public void handleMessage(Message msg) {
-			WebImageView view = mView.get();
+			WebImageView view = (WebImageView)getImageView();
 			if (view == null) {
 				return;
 			}
@@ -282,7 +280,7 @@ public class WebImageView extends ImageView {
 					view.mLoaded = true;
 					ImageLoadedCallback cb = mCallback.get();
 					if (cb != null) {
-						cb.imageLoaded(mView.get());
+						cb.imageLoaded(view);
 					}
 				}
 			}


### PR DESCRIPTION
Since the image loader had a strong reference to the image view, if the image view was removed from the window and discarded, it would not be garbage collected. This caused images to be leaked and eventual out of memory to occur.